### PR TITLE
Google SMTP credentials 제거

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,8 +2,8 @@ spring:
   mail:
     host: smtp.gmail.com # SMTP 서버 호스트
     port: 587 # SMTP 서버 포트
-    username: username # SMTP 서버 로그인 아이디 (발신자)
-    password: password # SMTP 서버 로그인 패스워드 (앱 비밀번호)
+    username: # SMTP 서버 로그인 아이디 (발신자)
+    password: # SMTP 서버 로그인 패스워드 (앱 비밀번호)
     properties:
       mail:
         smtp:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,8 +2,8 @@ spring:
   mail:
     host: smtp.gmail.com # SMTP 서버 호스트
     port: 587 # SMTP 서버 포트
-    username: cmwmss59 # SMTP 서버 로그인 아이디 (발신자)
-    password: hyobjvuujwuzfpcj # SMTP 서버 로그인 패스워드 (앱 비밀번호)
+    username: username # SMTP 서버 로그인 아이디 (발신자)
+    password: password # SMTP 서버 로그인 패스워드 (앱 비밀번호)
     properties:
       mail:
         smtp:


### PR DESCRIPTION
## 📝 작업 내용

- 리포지토리를 public으로 전환하면서 구글 SMTP 서버의 사용자 정보 유출 방지를 위해 해당 정보를 제거합니다.

## 📚 참고

## ❤️ 리뷰 요구사항
